### PR TITLE
Feat/내가판매등록카드필터링개수조회 api

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@prisma/client": "^6.5.0",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/cookie-parser": "^1.4.8",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.13.11",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,8 +4,18 @@ import routes from "./domains/routes";
 import { swaggerUi, swaggerSpec } from "./utils/swagger/swagger";
 import cookieParser from "cookie-parser";
 import { errorHandler } from "./middlewares/error.middleware";
+import cors from "cors";
 dotenv.config();
 const app = express();
+
+const corsOptions: cors.CorsOptions = {
+  origin: ["http://localhost:3000"], // 허용할 도메인
+  methods: ["GET", "POST", "PUT", "DELETE"], // 허용할 HTTP 메서드
+  credentials: true, // 쿠키 허용 여부
+};
+
+app.use(cors(corsOptions));
+app.use(express.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
 app.use(cookieParser());
 
 app.use(express.json());

--- a/src/domains/market/controllers/market.controller.ts
+++ b/src/domains/market/controllers/market.controller.ts
@@ -26,10 +26,20 @@ const getMarketListCount: ApiSignature = async (req, res) => {
   res.status(200).send(response);
 };
 
+const getMarketMeCount: ApiSignature = async (req, res) => {
+  const queries = req.query;
+  const userId = req.user.id;
+
+  const response = await marketService.getMarketMeCount(queries, userId);
+
+  res.status(200).send(response);
+};
+
 const marketController = {
   getMarketList,
   getMarketMe,
   getMarketListCount,
+  getMarketMeCount,
 };
 
 export default marketController;

--- a/src/domains/market/market.routes.ts
+++ b/src/domains/market/market.routes.ts
@@ -29,6 +29,12 @@ router.get(
   validateAll({ query: MarketMeQuerySchema }),
   requestHandler(marketController.getMarketMe)
 );
+router.get(
+  "/me/count",
+  authenticate,
+  validateAll({ query: MarketMeQuerySchema }),
+  requestHandler(marketController.getMarketMeCount)
+);
 
 router.get("/:id", authenticate, marketDetailController.getMarketItemDetail);
 

--- a/src/domains/market/services/market.service.ts
+++ b/src/domains/market/services/market.service.ts
@@ -6,12 +6,18 @@ import prisma from "../../../utils/prismaClient";
 import {
   GetMarketList,
   GetMarketListCount,
+  GetMarketMeCount,
   GetMarketMeList,
   MarketCardDto,
   PhotoCardInfo,
 } from "../types/market.type";
 import { MarketOfferDto } from "../../../types/dtos/marketOffer.dto";
-import { allGenres, allGrades, allSaleStatus } from "../../../types/enums.type";
+import {
+  allGenres,
+  allGrades,
+  allMarketStatus,
+  allSaleStatus,
+} from "../../../types/enums.type";
 
 /**
  *
@@ -279,103 +285,97 @@ const getMarketMe: GetMarketMeList = async (queries, user) => {
       }
     : null;
 
-  const saleCards = await prisma.saleCard.findMany({
-    where: {
-      sellerId: userId,
-      status: {
-        in: ["ON_SALE", "SOLD_OUT"],
-      },
-    },
-    include: {
-      photoCard: true, // 관계된 PhotoCard 정보 포함
-    },
-  });
-  const exchangeCards = await prisma.exchangeOffer.findMany({
-    where: {
-      offererId: userId,
-      status: {
-        in: ["PENDING"],
-      },
-    },
-    include: {
+  /* */
+  const marketOffersTmp = await prisma.marketOffer.findMany({
+    where: { ownerId: userId },
+    select: {
+      type: true,
       saleCard: {
-        include: {
-          photoCard: true,
+        select: {
+          photoCard: {
+            select: {
+              grade: true,
+              genre: true,
+            },
+          },
+          status: true,
+        },
+      },
+      exchangeOffer: {
+        select: {
+          saleCard: {
+            select: {
+              photoCard: {
+                select: {
+                  grade: true,
+                  genre: true,
+                },
+              },
+              status: true,
+            },
+          },
+          status: true,
         },
       },
     },
   });
 
-  // 판매카드와 교환카드의 포토카드 묶기
-  const allPhotoCards = [
-    ...saleCards.map((card) => card.photoCard),
-    ...exchangeCards.map((offer) => offer.saleCard.photoCard),
-  ];
+  // gradeInfo
+  const gradeInfo = allGrades.map((grade) => {
+    const count = marketOffersTmp.filter(
+      (offer) =>
+        (offer.type === "SALE" && offer.saleCard?.photoCard?.grade === grade) ||
+        (offer.type === "EXCHANGE" &&
+          offer.exchangeOffer?.saleCard?.photoCard?.grade === grade)
+    ).length;
 
-  // 등급별 그룹화
-  const grouped = allPhotoCards.reduce<Record<string, number>>(
-    (acc, photoCard) => {
-      const grade = photoCard.grade;
-      acc[grade] = (acc[grade] || 0) + 1;
-      return acc;
-    },
-    {}
-  );
+    return { name: grade, count };
+  });
 
-  // 배열 형태로 변환
-  const photoCardInfo = Object.entries(grouped).map(([name, count]) => ({
-    name,
-    count,
-  }));
+  // genreInfo
+  const genreInfo = allGenres.map((genre) => {
+    const count = marketOffersTmp.filter(
+      (offer) =>
+        (offer.type === "SALE" && offer.saleCard?.photoCard?.genre === genre) ||
+        (offer.type === "EXCHANGE" &&
+          offer.exchangeOffer?.saleCard?.photoCard?.genre === genre)
+    ).length;
 
-  // /* */
-  // let gradeResult = (await prisma.$queryRaw`
-  //     SELECT "photoCard"."grade", COUNT(*)
-  //     FROM "SaleCard" AS "saleCard"
-  //     JOIN "PhotoCard" AS "photoCard" ON "saleCard"."photoCardId" = "photoCard"."id"
-  //     WHERE "saleCard"."sellerId" = ${userId}
-  //     GROUP BY "photoCard"."grade"
-  //   `) as { grade: string; count: number }[];
-  // const gradeMap = new Map(gradeResult.map((r) => [r.grade, Number(r.count)]));
-  // const gradeInfo: PhotoCardInfo[] = allGrades.map((genre) => ({
-  //   name: genre,
-  //   count: gradeMap.get(genre) || 0,
-  // }));
+    return { name: genre, count };
+  });
 
-  // /* */
-  // const genreResult = (await prisma.$queryRaw`
-  //       SELECT "photoCard"."genre", COUNT(*)
-  //       FROM "SaleCard" AS "saleCard"
-  //       JOIN "PhotoCard" AS "photoCard" ON "saleCard"."photoCardId" = "photoCard"."id"
-  //       GROUP BY "photoCard"."genre"
-  //     `) as { genre: string; count: number }[];
-  // const resultMap = new Map(genreResult.map((r) => [r.genre, Number(r.count)]));
-  // const genreInfo: PhotoCardInfo[] = allGenres.map((genre) => ({
-  //   name: genre,
-  //   count: resultMap.get(genre) || 0,
-  // }));
+  // statusInfo
+  const statusInfo = allMarketStatus.map((status) => {
+    const count = marketOffersTmp.filter(
+      (offer) =>
+        (status === "PENDING" &&
+          offer.type === "EXCHANGE" &&
+          offer.exchangeOffer?.status === status) ||
+        (status !== "PENDING" &&
+          offer.type === "SALE" &&
+          offer.saleCard?.status === status)
+    ).length;
 
-  // /* */
-  // let statusResult = await prisma.saleCard.groupBy({
-  //   by: ["status"],
-  //   _count: {
-  //     _all: true,
-  //   },
-  // });
-  // const statusMap = new Map(statusResult.map((r) => [r.status, r._count._all]));
-  // const statusInfo: PhotoCardInfo[] = allSaleStatus.map((status) => ({
-  //   name: status,
-  //   count: statusMap.get(status) || 0,
-  // }));
+    return { name: status, count };
+  });
 
   return {
     hasMore,
     nextCursor,
     list: data,
-    photoCardInfo,
+    info: {
+      grade: gradeInfo,
+      genre: genreInfo,
+      status: statusInfo,
+    },
   };
 };
 
+/**
+ *
+ * @param queries
+ * @returns
+ */
 const getMarketListCount: GetMarketListCount = async (queries) => {
   const { genre, grade, status } = queries;
 
@@ -397,10 +397,94 @@ const getMarketListCount: GetMarketListCount = async (queries) => {
   };
 };
 
+/**
+ *
+ * @param queries
+ * @param userId
+ * @returns
+ */
+const getMarketMeCount: GetMarketMeCount = async (queries, userId) => {
+  const { genre, grade, status } = queries;
+
+  const isExchange = status === "PENDING";
+  const isSale = status === "ON_SALE" || status === "SOLD_OUT";
+
+  let where: any = {
+    ownerId: userId,
+  };
+
+  if (!status) {
+    // status 없을 때 (모두 사용)
+    where = {
+      ownerId: userId,
+      OR: [
+        {
+          type: "SALE",
+          saleCard: {
+            photoCard: {
+              ...(grade ? { grade } : {}),
+              ...(genre ? { genre } : {}),
+            },
+          },
+        },
+        {
+          type: "EXCHANGE",
+          exchangeOffer: {
+            saleCard: {
+              photoCard: {
+                ...(grade ? { grade } : {}),
+                ...(genre ? { genre } : {}),
+              },
+            },
+          },
+        },
+      ],
+    };
+  } else if (isSale) {
+    // ON_SALE | SOLD_OUT
+    where = {
+      ownerId: userId,
+      type: "SALE",
+      saleCard: {
+        status,
+        photoCard: {
+          ...(grade ? { grade } : {}),
+          ...(genre ? { genre } : {}),
+        },
+      },
+    };
+  } else if (isExchange) {
+    // PENDING
+    where = {
+      ownerId: userId,
+      type: "EXCHANGE",
+      exchangeOffer: {
+        status: "PENDING",
+        saleCard: {
+          photoCard: {
+            ...(grade ? { grade } : {}),
+            ...(genre ? { genre } : {}),
+          },
+        },
+      },
+    };
+  }
+
+  const count = await prisma.marketOffer.count({ where });
+
+  return {
+    grade: grade || "ALL",
+    genre: genre || "ALL",
+    status: status || "ALL",
+    count,
+  };
+};
+
 const marketService = {
   getMarketList,
   getMarketMe,
   getMarketListCount,
+  getMarketMeCount,
 };
 
 export default marketService;

--- a/src/domains/market/types/market.type.ts
+++ b/src/domains/market/types/market.type.ts
@@ -20,6 +20,10 @@ export type GetMarketMeList = (
 export type GetMarketListCount = (
   queries: MarketListCountQuery
 ) => Promise<MarketListCountResponse>;
+export type GetMarketMeCount = (
+  queries: MarketListCountQuery,
+  userId: string
+) => Promise<MarketListCountResponse>;
 
 export interface MarketListCountResponse {
   grade: string;
@@ -54,7 +58,7 @@ export interface MarketMeListResponse {
     createdAt: string;
   } | null;
   list: MarketMeResponse[];
-  photoCardInfo: PhotoCardInfo[];
+  info: FilterPhotoCard;
 }
 
 export interface MarketResponse {

--- a/src/types/enums.type.ts
+++ b/src/types/enums.type.ts
@@ -1,3 +1,4 @@
 export const allGrades = ["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"];
 export const allGenres = ["TRAVEL", "LANDSCAPE", "PORTRAIT", "OBJECT"];
 export const allSaleStatus = ["ON_SALE", "SOLD_OUT"];
+export const allMarketStatus = ["ON_SALE", "SOLD_OUT", "PENDING"];


### PR DESCRIPTION
## 📌 개요

- 내가 판매 등록한 포토카드 목록 조회 페이지에서 필터링 옵션 별 개수 추가
- 필터링 선택 시 최종 포토카드 개수 조회 API 구현
- cors 허용 추가

## ✨ 주요 변경 사항

- 

## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

- `http://localhost:3000` 만 허용

## 🔗 관련 이슈

- #52 

## 🖼️ 스크린샷

`GET /api/market/me`

![image](https://github.com/user-attachments/assets/89164e8f-fcb6-4fc2-a7da-168fe9451cc5)

`GET /api/market/me/count`

![image](https://github.com/user-attachments/assets/078edb8d-cdf4-4484-9404-f6fb3e2a0c38)

