### PR TITLE
Fix/포토카드 전체조회 수정

### DIFF
--- a/src/domains/market/validators/market.update.validators.ts
+++ b/src/domains/market/validators/market.update.validators.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // 포토카드 수정을 위한 검증 스키마
 export const UpdateMarketItemSchema = z.object({
-  quantity: z.number().min(1).max(10).optional(),
+  quantity: z.number().min(1).optional(),
   price: z.number().min(0).optional(),
   exchangeOffer: z
     .object({

--- a/src/domains/photocards/services/photocard.service.ts
+++ b/src/domains/photocards/services/photocard.service.ts
@@ -8,6 +8,7 @@ import {
   Cursor,
 } from "../types/photocard.type";
 import { PHOTOCARD_GENRES } from "../constants/filter.constant";
+import { Prisma } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -93,8 +94,57 @@ const getMyPhotocards = async (
     nextCursor = null;
   }
 
-  // 포토카드 ID 목록
-  const photoCardIds = userPhotoCards.map((card) => card.photoCardId);
+  // 판매 중인 카드의 수량 조회
+  const saleCards = await prisma.saleCard.findMany({
+    where: {
+      sellerId: userId,
+      status: "ON_SALE",
+      userPhotoCardId: {
+        in: userPhotoCards.map((card) => card.id),
+      },
+    },
+    select: {
+      userPhotoCardId: true,
+      quantity: true,
+    },
+  });
+
+  // 교환 제시 중(PENDING)인 카드 수량 조회
+  const exchangeOffers = await prisma.exchangeOffer.findMany({
+    where: {
+      offererId: userId,
+      status: "PENDING",
+      userPhotoCardId: {
+        in: userPhotoCards.map((card) => card.id),
+      },
+    },
+    select: {
+      userPhotoCardId: true,
+    },
+  });
+
+  // 교환 제시 중인 카드 수량 맵 (제안 1개당 1장 교환)
+  const exchangeOfferMap = new Map();
+  exchangeOffers.forEach((offer) => {
+    const count = exchangeOfferMap.get(offer.userPhotoCardId) || 0;
+    exchangeOfferMap.set(offer.userPhotoCardId, count + 1);
+  });
+
+  // 판매 중인 카드의 수량 맵 생성
+  const saleCardMap = new Map();
+  saleCards.forEach((card) => {
+    saleCardMap.set(card.userPhotoCardId, card.quantity);
+  });
+
+  // 가용 수량이 1 이상인 카드만 필터링
+  const availableUserPhotoCards = userPhotoCards.filter((card) => {
+    const saleQuantity = saleCardMap.get(card.id) || 0;
+    const offerQuantity = exchangeOfferMap.get(card.id) || 0;
+    return card.quantity - saleQuantity - offerQuantity > 0;
+  });
+
+  // 포토카드 ID 목록 (가용 수량이 있는 것만)
+  const photoCardIds = availableUserPhotoCards.map((card) => card.photoCardId);
 
   // 필터링 조건 구성
   const photoCardWhereClause = await buildWhereClause({
@@ -116,24 +166,37 @@ const getMyPhotocards = async (
     },
   });
 
-  // 수량 정보 매핑
-  const userPhotoCardMap = new Map(
-    userPhotoCards.map((card) => [card.photoCardId, card.quantity])
-  );
+  // 실제 가용 수량 계산
+  const userPhotoCardMap = new Map();
+  availableUserPhotoCards.forEach((card) => {
+    const saleQuantity = saleCardMap.get(card.id) || 0;
+    const offerQuantity = exchangeOfferMap.get(card.id) || 0;
+    userPhotoCardMap.set(card.photoCardId, {
+      userPhotoCardId: card.id,
+      quantity: card.quantity - saleQuantity - offerQuantity,
+    });
+  });
 
   // 응답 데이터 매핑
-  const mappedPhotocards: PhotocardInfo[] = photoCards.map((photoCard) => ({
-    id: photoCard.id,
-    name: photoCard.name,
-    imageUrl: photoCard.imageUrl,
-    grade: photoCard.grade,
-    genre: photoCard.genre,
-    description: photoCard.description,
-    price: photoCard.price,
-    amount: userPhotoCardMap.get(photoCard.id) || 0,
-    createdAt: photoCard.createdAt.toISOString(),
-    creatorNickname: photoCard.creator.nickname,
-  }));
+  const mappedPhotocards: PhotocardInfo[] = photoCards
+    .map((photoCard) => {
+      const cardInfo = userPhotoCardMap.get(photoCard.id);
+      if (!cardInfo) return null; // 가용 수량 없으면 null
+
+      return {
+        id: cardInfo.userPhotoCardId,
+        name: photoCard.name,
+        imageUrl: photoCard.imageUrl,
+        grade: photoCard.grade,
+        genre: photoCard.genre,
+        description: photoCard.description,
+        price: photoCard.price,
+        amount: cardInfo.quantity,
+        createdAt: photoCard.createdAt.toISOString(),
+        creatorNickname: photoCard.creator.nickname,
+      };
+    })
+    .filter(Boolean) as PhotocardInfo[]; // null 값 필터링
 
   // 필터링 후 결과가 없는 경우
   if (mappedPhotocards.length === 0) {
@@ -253,12 +316,36 @@ const getGradeCounts = async (userId: string): Promise<GradeCounts> => {
     LEGENDARY: 0,
   };
 
-  // SQL 쿼리로 등급별 개수 집계
+  // 판매 중인 카드와 교환 제시 중인 카드를 고려한 SQL 쿼리
   const result = await prisma.$queryRaw`
-    SELECT p."grade", COUNT(DISTINCT u."photoCardId") as count
+    WITH SaleQuantities AS (
+      SELECT 
+        up."photoCardId",
+        COALESCE(SUM(s."quantity"), 0) as sale_quantity
+      FROM "SaleCard" s
+      JOIN "UserPhotoCard" up ON s."userPhotoCardId" = up."id"
+      WHERE s."sellerId" = ${userId} AND s."status" = 'ON_SALE'
+      GROUP BY up."photoCardId"
+    ),
+    ExchangeQuantities AS (
+      SELECT 
+        u."photoCardId",
+        COUNT(*) as offer_quantity
+      FROM "ExchangeOffer" e
+      JOIN "UserPhotoCard" u ON e."userPhotoCardId" = u."id"
+      WHERE e."offererId" = ${userId} AND e."status" = 'PENDING'
+      GROUP BY u."photoCardId"
+    )
+    SELECT 
+      p."grade", 
+      COUNT(DISTINCT u."photoCardId") as count
     FROM "UserPhotoCard" u
     JOIN "PhotoCard" p ON u."photoCardId" = p."id"
-    WHERE u."ownerId" = ${userId}
+    LEFT JOIN SaleQuantities sq ON u."photoCardId" = sq."photoCardId"
+    LEFT JOIN ExchangeQuantities eq ON u."photoCardId" = eq."photoCardId"
+    WHERE 
+      u."ownerId" = ${userId}
+      AND (u."quantity" - COALESCE(sq.sale_quantity, 0) - COALESCE(eq.offer_quantity, 0)) > 0
     GROUP BY p."grade"
   `;
 
@@ -277,22 +364,58 @@ const getGradeCounts = async (userId: string): Promise<GradeCounts> => {
  * 필터링 정보를 조회하는 함수
  */
 const getFilterInfo = async (userId: string): Promise<FilterPhotoCard> => {
+  // 판매 중인 카드와 교환 제시 중인 카드를 고려한 공통 쿼리 부분
+  const commonQueryPart = `
+    WITH SaleQuantities AS (
+      SELECT 
+        up."photoCardId",
+        COALESCE(SUM(s."quantity"), 0) as sale_quantity
+      FROM "SaleCard" s
+      JOIN "UserPhotoCard" up ON s."userPhotoCardId" = up."id"
+      WHERE s."sellerId" = '${userId}' AND s."status" = 'ON_SALE'
+      GROUP BY up."photoCardId"
+    ),
+    ExchangeQuantities AS (
+      SELECT 
+        u."photoCardId",
+        COUNT(*) as offer_quantity
+      FROM "ExchangeOffer" e
+      JOIN "UserPhotoCard" u ON e."userPhotoCardId" = u."id"
+      WHERE e."offererId" = '${userId}' AND e."status" = 'PENDING'
+      GROUP BY u."photoCardId"
+    )
+  `;
+
   // 등급별 필터 정보 조회
   const gradeFilterQuery = await prisma.$queryRaw`
-    SELECT p."grade" as name, COUNT(DISTINCT u."photoCardId") as count
+    ${Prisma.raw(commonQueryPart)}
+    SELECT 
+      p."grade" as name, 
+      COUNT(DISTINCT u."photoCardId") as count
     FROM "UserPhotoCard" u
     JOIN "PhotoCard" p ON u."photoCardId" = p."id"
-    WHERE u."ownerId" = ${userId}
+    LEFT JOIN SaleQuantities sq ON u."photoCardId" = sq."photoCardId"
+    LEFT JOIN ExchangeQuantities eq ON u."photoCardId" = eq."photoCardId"
+    WHERE 
+      u."ownerId" = ${userId}
+      AND (u."quantity" - COALESCE(sq.sale_quantity, 0) - COALESCE(eq.offer_quantity, 0)) > 0
     GROUP BY p."grade"
     ORDER BY count DESC
   `;
 
   // 장르별 필터 정보 조회
   const genreFilterQuery = await prisma.$queryRaw`
-    SELECT p."genre" as name, COUNT(DISTINCT u."photoCardId") as count
+    ${Prisma.raw(commonQueryPart)}
+    SELECT 
+      p."genre" as name, 
+      COUNT(DISTINCT u."photoCardId") as count
     FROM "UserPhotoCard" u
     JOIN "PhotoCard" p ON u."photoCardId" = p."id"
-    WHERE u."ownerId" = ${userId}
+    LEFT JOIN SaleQuantities sq ON u."photoCardId" = sq."photoCardId"
+    LEFT JOIN ExchangeQuantities eq ON u."photoCardId" = eq."photoCardId"
+    WHERE 
+      u."ownerId" = ${userId}
+      AND (u."quantity" - COALESCE(sq.sale_quantity, 0) - COALESCE(eq.offer_quantity, 0)) > 0
     GROUP BY p."genre"
     ORDER BY count DESC
   `;

--- a/src/domains/photocards/types/photocard.type.ts
+++ b/src/domains/photocards/types/photocard.type.ts
@@ -35,7 +35,7 @@ export interface Cursor {
  * 포토카드 상세 정보 인터페이스
  */
 export interface PhotocardInfo {
-  id: string;
+  id: string | null;
   name: string;
   imageUrl: string;
   grade: string;
@@ -73,7 +73,7 @@ export type CursorType = Cursor;
 export type PhotocardResponse = PhotocardInfo;
 
 export type PhotocardDto = {
-  id: string;
+  id: string | null;
   name: string;
   imageUrl: string;
   grade: string;


### PR DESCRIPTION
## 수정 내용
1. 내 포토카드 조회 API 개선
   - 실제 사용 가능한 카드만 조회되도록 수정
   - 판매 등록된 카드와 교환 제안 중(PENDING)인 카드는 가용 수량(amount)에서 제외
   - amount가 0인 카드는 조회 결과에서 제외

2. 포토카드 ID 참조 관계 개선
   - 내 포토카드 조회 시 id가 userPhotoCard의 ID를 반환하도록 수정

3. 필터링 일관성 개선
   - 등급별/장르별 필터 카운트에도 동일한 로직 적용
   - 판매 중인 카드와 교환 제안 중인 카드를 제외한 정확한 카운트 표시

## 해결된 문제점
1. 교환 제안 API 호출 시 userPhotoCardId 불일치 오류 해결
2. 필터링 시 표시되는 카드 수량과 실제 조회되는 카드 수량 불일치 해결
3. 판매 등록 및 교환 제안 시 동일 카드의 중복 처리 방지

## 테스트 방법
1. 포토카드 조회 → 판매 등록 → 다시 조회하여 amount 감소 확인
2. 포토카드 조회 → 교환 제안 → 다시 조회하여 amount 감소 확인
3. 필터 카운트와 실제 조회 결과 수량 일치 여부 확인