### PR TITLE
fix: 내 판매 등록 카드 목록 조회 API 응답 수정

### DIFF
--- a/prisma/migrations/20250410042254_/migration.sql
+++ b/prisma/migrations/20250410042254_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[ownerId,photoCardId]` on the table `UserPhotoCard` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "UserPhotoCard_ownerId_photoCardId_key" ON "UserPhotoCard"("ownerId", "photoCardId");

--- a/prisma/schema/exchangeOffer.prisma
+++ b/prisma/schema/exchangeOffer.prisma
@@ -1,13 +1,14 @@
 model ExchangeOffer {
-  id              String   @id @default(uuid())
-  offererId       String
-  userPhotoCardId String
-  status          String
-  content         String
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  id        String   @id @default(uuid())
+  offererId String
+  status    String
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  saleCard    SaleCard     @relation(fields: [saleCardId], references: [id])
-  saleCardId  String
-  marketOffer MarketOffer?
+  saleCardId      String
+  saleCard        SaleCard      @relation(fields: [saleCardId], references: [id])
+  userPhotoCardId String
+  userPhotoCard   UserPhotoCard @relation(fields: [userPhotoCardId], references: [id])
+  marketOffer     MarketOffer?
 }

--- a/prisma/schema/photoCard.prisma
+++ b/prisma/schema/photoCard.prisma
@@ -9,9 +9,10 @@ model PhotoCard {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  saleCard  SaleCard[]
-  creator   User       @relation(fields: [creatorId], references: [id])
-  creatorId String
+  userPhotoCard UserPhotoCard[]
+  saleCard      SaleCard[]
+  creatorId     String
+  creator       User            @relation(fields: [creatorId], references: [id])
 
   @@index([grade, genre])
 }

--- a/prisma/schema/userPhotoCard.prisma
+++ b/prisma/schema/userPhotoCard.prisma
@@ -1,12 +1,14 @@
 model UserPhotoCard {
-  id          String   @id @default(uuid())
-  ownerId     String
-  photoCardId String
-  quantity    Int
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id        String   @id @default(uuid())
+  ownerId   String
+  quantity  Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  saleCard SaleCard[]
+  saleCard      SaleCard[]
+  exchangeOffer ExchangeOffer[]
+  photoCardId   String
+  photoCard     PhotoCard       @relation(fields: [photoCardId], references: [id])
 
   @@unique([ownerId, photoCardId]) // ownerId_photoCardId
   @@index([ownerId])

--- a/src/domains/market/services/market.service.ts
+++ b/src/domains/market/services/market.service.ts
@@ -289,7 +289,7 @@ const getMarketMe: GetMarketMeList = async (queries, user) => {
 
   // console.log(JSON.stringify(enrichedOffers, null, 2));
 
-  console.log(enrichedOffers);
+  // console.log(enrichedOffers);
 
   const data = enrichedOffers.map((card) => toMarketMeResponse(card));
 

--- a/src/domains/market/services/market.service.ts
+++ b/src/domains/market/services/market.service.ts
@@ -184,7 +184,10 @@ const getMarketMe: GetMarketMeList = async (queries, user) => {
       saleCard: { include: { photoCard: { include: { creator: true } } } },
       exchangeOffer: {
         include: {
-          saleCard: { include: { photoCard: { include: { creator: true } } } },
+          saleCard: true,
+          userPhotoCard: {
+            include: { photoCard: { include: { creator: true } } },
+          },
         },
       },
     },
@@ -285,6 +288,8 @@ const getMarketMe: GetMarketMeList = async (queries, user) => {
   });
 
   // console.log(JSON.stringify(enrichedOffers, null, 2));
+
+  console.log(enrichedOffers);
 
   const data = enrichedOffers.map((card) => toMarketMeResponse(card));
 

--- a/src/domains/market/types/market.type.ts
+++ b/src/domains/market/types/market.type.ts
@@ -101,7 +101,9 @@ export interface MarketResponse {
   updatedAt: string;
 }
 export interface MarketMeResponse {
-  saleCardId: string;
+  id: string;
+  saleCardId: string | null;
+  exchangeOfferId: string | null;
   status: string;
   name: string;
   genre: string;

--- a/src/domains/market/types/market.type.ts
+++ b/src/domains/market/types/market.type.ts
@@ -102,7 +102,7 @@ export interface MarketResponse {
 }
 export interface MarketMeResponse {
   id: string;
-  saleCardId: string | null;
+  saleCardId: string;
   exchangeOfferId: string | null;
   status: string;
   name: string;

--- a/src/domains/market/validators/market.validator.ts
+++ b/src/domains/market/validators/market.validator.ts
@@ -2,13 +2,9 @@ import { z } from "zod";
 
 export const MarketListQuerySchema = z.object({
   keyword: z.string().optional(),
-  grade: z
-    .enum(["ALL", "COMMON", "RARE", "SUPER_RARE", "LEGENDARY"])
-    .optional(),
-  genre: z
-    .enum(["ALL", "LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"])
-    .optional(),
-  status: z.enum(["ALL", "ON_SALE", "SOLD_OUT", "CANCELED"]).optional(),
+  grade: z.enum(["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"]).optional(),
+  genre: z.enum(["LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"]).optional(),
+  status: z.enum(["ON_SALE", "SOLD_OUT", "CANCELED"]).optional(),
   sort: z.enum(["recent", "old", "cheap", "expensive"]).optional(),
   limit: z
     .string()
@@ -19,13 +15,9 @@ export const MarketListQuerySchema = z.object({
 
 export const MarketMeQuerySchema = z.object({
   keyword: z.string().optional(),
-  grade: z
-    .enum(["ALL", "COMMON", "RARE", "SUPER_RARE", "LEGENDARY"])
-    .optional(),
-  genre: z
-    .enum(["ALL", "LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"])
-    .optional(),
-  status: z.enum(["ALL", "ON_SALE", "SOLD_OUT", "PENDING"]).optional(),
+  grade: z.enum(["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"]).optional(),
+  genre: z.enum(["LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"]).optional(),
+  status: z.enum(["ON_SALE", "SOLD_OUT", "PENDING"]).optional(),
   limit: z
     .string()
     .optional()
@@ -35,16 +27,14 @@ export const MarketMeQuerySchema = z.object({
 
 export const MarketListCountQuerySchema = z.object({
   grade: z.enum(["COMMON", "RARE", "SUPER_RARE", "LEGENDARY"]).optional(),
-  genre: z
-    .enum(["ALL", "LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"])
-    .optional(),
+  genre: z.enum(["LANDSCAPE", "PORTRAIT", "TRAVEL", "OBJECT"]).optional(),
   status: z.enum(["ON_SALE", "SOLD_OUT", "PENDING"]).optional(),
 });
 
 export const RequestMarketItemSchema = z.object({
   userPhotoCardId: z.string(),
-  quantity: z.number().min(1).max(10),
-  price: z.number().min(0),
+  quantity: z.number().min(1),
+  price: z.number().min(1),
   exchangeOffer: z
     .object({
       grade: z.string(),

--- a/src/utils/dtos/exchangeOffer.dto.ts
+++ b/src/utils/dtos/exchangeOffer.dto.ts
@@ -1,4 +1,5 @@
 import { saleCardDto } from "./saleCard.dto";
+import { UserPhotoCardDto } from "./userPhotoCard.dto";
 
 export interface ExchangeOfferDto {
   id: string;
@@ -9,4 +10,5 @@ export interface ExchangeOfferDto {
   createdAt: Date;
   updatedAt: Date;
   saleCard: saleCardDto;
+  userPhotoCard: UserPhotoCardDto;
 }

--- a/src/utils/dtos/marketOffer.dto.ts
+++ b/src/utils/dtos/marketOffer.dto.ts
@@ -1,18 +1,6 @@
 import { ExchangeOfferDto } from "./exchangeOffer.dto";
 import { saleCardDto } from "./saleCard.dto";
 
-// export interface MarketOfferDto {
-//   id: string;
-//   type: string;
-//   ownerId: string;
-//   createdAt: Date;
-//   updatedAt: Date;
-//   saleCardId: string | null;
-//   exchangeOfferId: string | null;
-//   saleCard: saleCardDto | null;
-//   exchangeOffer: ExchangeOfferDto | null;
-// }
-
 export interface MarketOfferDto {
   id: string;
   type: string;

--- a/src/utils/dtos/saleCard.dto.ts
+++ b/src/utils/dtos/saleCard.dto.ts
@@ -14,6 +14,6 @@ export interface saleCardDto {
   updatedAt: Date;
   totalTradedQuantity?: number;
   seller?: UserDto;
-  photoCard: PhotoCardDto;
+  photoCard?: PhotoCardDto;
   userPhotoCard?: UserPhotoCardDto;
 }

--- a/src/utils/dtos/userPhotoCard.dto.ts
+++ b/src/utils/dtos/userPhotoCard.dto.ts
@@ -1,9 +1,11 @@
+import { PhotoCardDto } from "./photoCard.dto";
+
 export interface UserPhotoCardDto {
   id: string;
   ownerId: string;
   photoCardId: string;
   quantity: number;
-  status: string;
   createdAt: Date;
   updatedAt: Date;
+  photoCard: PhotoCardDto;
 }

--- a/src/utils/mappers/market.mapper.ts
+++ b/src/utils/mappers/market.mapper.ts
@@ -39,18 +39,38 @@ export const toMarketResponse = (
 export const toMarketMeResponse = (card: MarketOfferDto): MarketMeResponse => {
   const offer = card.saleCard
     ? {
+        saleCardId: card.saleCard.id,
+        exchangeOfferId: null,
         status: card.saleCard.status,
-        saleCard: card.saleCard,
-        total: card.saleCard.quantity,
+        name: card.saleCard.photoCard!.name,
+        genre: card.saleCard.photoCard!.genre,
+        grade: card.saleCard.photoCard!.grade,
+        price: card.saleCard.price,
+        image: card.saleCard.photoCard!.imageUrl,
         remaining:
           card.saleCard.quantity - (card.saleCard.totalTradedQuantity || 0),
+        total: card.saleCard.quantity,
+        creator: {
+          id: card.saleCard.photoCard!.creator.id,
+          nickname: card.saleCard.photoCard!.creator.nickname,
+        },
       }
     : card.exchangeOffer
     ? {
+        saleCardId: card.exchangeOffer.saleCard.id,
+        exchangeOfferId: card.exchangeOffer.id,
         status: card.exchangeOffer.status,
-        saleCard: card.exchangeOffer.saleCard,
-        total: 1,
+        name: card.exchangeOffer.userPhotoCard.photoCard.name,
+        genre: card.exchangeOffer.userPhotoCard.photoCard.genre,
+        grade: card.exchangeOffer.userPhotoCard.photoCard.grade,
+        price: card.exchangeOffer.userPhotoCard.photoCard.price,
+        image: card.exchangeOffer.userPhotoCard.photoCard.imageUrl,
         remaining: 1,
+        total: 1,
+        creator: {
+          id: card.exchangeOffer.userPhotoCard.photoCard.creator.id,
+          nickname: card.exchangeOffer.userPhotoCard.photoCard.creator.nickname,
+        },
       }
     : null;
 
@@ -60,19 +80,18 @@ export const toMarketMeResponse = (card: MarketOfferDto): MarketMeResponse => {
     );
 
   return {
-    saleCardId: card.id,
+    id: card.id,
+    saleCardId: offer.saleCardId,
+    exchangeOfferId: offer.exchangeOfferId,
     status: offer.status,
-    name: offer.saleCard.photoCard.name,
-    genre: offer.saleCard.photoCard.genre,
-    grade: offer.saleCard.photoCard.grade,
-    price: offer.saleCard.price,
-    image: offer.saleCard.photoCard.imageUrl,
-    total: offer.total,
+    name: offer.name,
+    genre: offer.genre,
+    grade: offer.grade,
+    price: offer.price,
+    image: offer.image,
     remaining: offer.remaining,
-    creator: {
-      id: offer.saleCard.photoCard.creator.id,
-      nickname: offer.saleCard.photoCard.creator.nickname,
-    },
+    total: offer.total,
+    creator: offer.creator,
     createdAt: card.createdAt.toISOString(),
     updatedAt: card.updatedAt.toISOString(),
   };


### PR DESCRIPTION
## 📌 개요

- 내가 판매 등록한 포토카드 목록 조회 API 응답값 수정

## ✨ 주요 변경 사항

- 스키마 relation 맺음 : `UserPhotoCard` - `PhotoCard`
- 응답값에 `exchangeOfferId` 추가
 
## 📢 공유 사항(다른 팀원들도 알아두어야 할 것들)

-

## 🔗 관련 이슈

-

## 🖼️ 스크린샷

- 
